### PR TITLE
feat: add iOS standalone PWA support for fullscreen

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,8 +2,15 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>SMB1 Web Gameplay</title>
+
+  <!-- iOS: run without Safari UI when launched from Home Screen -->
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black" />
+  <meta name="theme-color" content="#000000" media="(prefers-color-scheme: dark)">
+  <meta name="theme-color" content="#000000" media="(prefers-color-scheme: light)">
+
   <link rel="stylesheet" href="./style.css" />
   <script type="importmap">
     {

--- a/src/main.ts
+++ b/src/main.ts
@@ -184,8 +184,12 @@ function maybeStartSmb2LikeStageFade() {
 }
 
 function resizeCanvasToDisplaySize(canvasElem: HTMLCanvasElement) {
-  const width = Math.floor(canvasElem.clientWidth * window.devicePixelRatio);
-  const height = Math.floor(canvasElem.clientHeight * window.devicePixelRatio);
+  const dpr = window.devicePixelRatio || 1;
+  const viewport = window.visualViewport;
+  const cssWidth = viewport?.width || canvasElem.clientWidth || window.innerWidth;
+  const cssHeight = viewport?.height || canvasElem.clientHeight || window.innerHeight;
+  const width = Math.floor(cssWidth * dpr);
+  const height = Math.floor(cssHeight * dpr);
   if (canvasElem.width !== width || canvasElem.height !== height) {
     canvasElem.width = width;
     canvasElem.height = height;

--- a/style.css
+++ b/style.css
@@ -1,5 +1,6 @@
+/* I changed the color-scheme because of the notch on ios ) : */
 :root {
-  color-scheme: light;
+  color-scheme: dark;
   --bg: #0b0b10;
   --fg: #f3f3f3;
   --muted: #b7b7c2;
@@ -11,7 +12,12 @@
   box-sizing: border-box;
 }
 
-html,
+/* iOS standalone: black background prevents white flash on load and sets notch/safe-area color */
+html {
+  height: 100%;
+  background-color: #000;
+}
+
 body {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
## Description
Hi! I love this project—I remember playing this game as a kid (although I'm terrible at it). I wanted to play on my iPhone, but the Safari UI is really annoying, so I added the necessary meta tags to enable PWA support and allow the app to run in fullscreen mode on iOS.

Thank you so much for all your work, it's incredible, it runs really smooth.

## Changes
- Added iOS PWA meta tags (`apple-mobile-web-app-capable`, `apple-mobile-web-app-status-bar-style`)
- Added `viewport-fit=cover` to extend content under the notch/safe areas
- Added `theme-color` meta tags to prevent the status bar area from changing color based on system dark/light mode
- Added `color-scheme: dark` because of the notch ) : 
- Fixed canvas sizing for iOS standalone mode using `visualViewport` API

## Steps
- Load webapp.
- On safari -> share_button -> Add to Home Screen
- FullScreen <3

## Screenshots
### Vertical: Before - After
<img width="300" alt="Vertical before - Safari UI visible" src="https://github.com/user-attachments/assets/3f45b297-e94f-4a10-8377-879f22151414" />
<img width="300" alt="Vertical after - Fullscreen mode" src="https://github.com/user-attachments/assets/8d393433-70bb-42cb-9445-e2417a5bfa2a" />
 
### Horizontal: Before - After
<img width="400" alt="Horizontal before - Safari UI visible" src="https://github.com/user-attachments/assets/3008919f-e784-48dd-943c-eb02375133c3" />

<img width="400" alt="Horizontal after - Fullscreen mode" src="https://github.com/user-attachments/assets/d6ccec16-2965-4746-9ed1-5c4eae0b32a8" />