### PR TITLE
Add 2D player sprites

### DIFF
--- a/index.html
+++ b/index.html
@@ -592,6 +592,20 @@
                 <button id="profile-ball-hemi2-texture-clear" class="ghost compact" type="button">Clear Hemisphere 2 Texture</button>
               </label>
             </div>
+            <div class="profile-ball-texture-row">
+              <label class="field">
+                <span>Player Texture (4x3 spritesheet)</span>
+                <input
+                  id="profile-player-billboard-texture-input"
+                  class="text-input"
+                  type="file"
+                  accept="image/png,image/jpeg,image/webp"
+                />
+                <button id="profile-player-billboard-texture-clear" class="ghost compact" type="button">Clear Player Texture</button>
+              </label>
+            </div>
+            <div id="profile-player-billboard-texture-error" class="control-hint hidden"></div>
+            <div class="control-hint">Ball textures sync in multiplayer. Max 512x512 and 100kb per hemisphere, max 1024x768 and 200kb per player spritesheet</div>
             <div class="profile-ball-preview-row">
               <div class="profile-ball-preview-label">Ball Preview</div>
               <div class="profile-ball-preview-window">
@@ -599,7 +613,6 @@
               </div>
             </div>
             <div id="profile-ball-texture-error" class="control-hint hidden"></div>
-            <div class="control-hint">Ball textures sync in multiplayer. Max 512x512 and 100kb per hemisphere.</div>
           </div>
           <div class="panel-section">
             <div class="panel-section-header">

--- a/src/app/main/dom_refs.ts
+++ b/src/app/main/dom_refs.ts
@@ -174,6 +174,9 @@ export function collectMainDomRefs() {
   const hidePlayerNamesToggle = document.getElementById('hide-player-names') as HTMLInputElement | null;
   const hideLobbyNamesToggle = document.getElementById('hide-lobby-names') as HTMLInputElement | null;
   const hideRemoteBallTexturesToggle = document.getElementById('hide-remote-ball-textures') as HTMLInputElement | null;
+  const profilePlayerBillboardTextureInput = document.getElementById('profile-player-billboard-texture-input') as HTMLInputElement | null;
+  const profilePlayerBillboardTextureClearButton = document.getElementById('profile-player-billboard-texture-clear') as HTMLButtonElement | null;
+  const profilePlayerBillboardTextureError = document.getElementById('profile-player-billboard-texture-error') as HTMLElement | null;
 
   const nameplateLayer = document.createElement('div');
   nameplateLayer.id = 'nameplate-layer';
@@ -349,6 +352,9 @@ export function collectMainDomRefs() {
     profileBallHemi2TextureClearButton,
     profileBallPreviewCanvas,
     profileBallTextureError,
+    profilePlayerBillboardTextureInput,
+    profilePlayerBillboardTextureClearButton,
+    profilePlayerBillboardTextureError,
     hidePlayerNamesToggle,
     hideLobbyNamesToggle,
     hideRemoteBallTexturesToggle,

--- a/src/app/netplay/ball_preview.ts
+++ b/src/app/netplay/ball_preview.ts
@@ -301,6 +301,7 @@ export class BallPreviewController {
     ballAppearance.hemi2Color = appearance.hemi2Color;
     ballAppearance.hemi1Texture = appearance.hemi1Texture;
     ballAppearance.hemi2Texture = appearance.hemi2Texture;
+    ballAppearance.playerBillboardTexture = appearance.playerBillboardTexture;
     this.spinRadians += (deltaMs / 1000) * PREVIEW_BALL_SPIN_RADIANS_PER_SECOND;
     if (this.spinRadians > (Math.PI * 2)) {
       this.spinRadians -= Math.PI * 2;

--- a/src/app/netplay/lobby_bindings.ts
+++ b/src/app/netplay/lobby_bindings.ts
@@ -19,6 +19,8 @@ type LobbyBindingsOptions = {
   profileBallHemi2TextureInput: HTMLInputElement | null;
   profileBallHemi1TextureClearButton: HTMLButtonElement | null;
   profileBallHemi2TextureClearButton: HTMLButtonElement | null;
+  profilePlayerBillboardTextureInput: HTMLInputElement | null;
+  profilePlayerBillboardTextureClearButton: HTMLButtonElement | null;
   hidePlayerNamesToggle: HTMLInputElement | null;
   hideLobbyNamesToggle: HTMLInputElement | null;
   hideRemoteBallTexturesToggle: HTMLInputElement | null;
@@ -44,8 +46,10 @@ type LobbyBindingsOptions = {
   onProfileBallHemi2ColorInput: (value: string, input: HTMLInputElement) => void;
   onProfileBallHemi1TextureChange: (file: File | null) => Promise<void>;
   onProfileBallHemi2TextureChange: (file: File | null) => Promise<void>;
+  onProfilePlayerBillboardTextureChange: (file: File | null) => Promise<void>;
   onProfileBallHemi1TextureClear: () => void;
   onProfileBallHemi2TextureClear: () => void;
+  onProfilePlayerBillboardTextureClear: () => void;
   onHidePlayerNamesChange: (checked: boolean) => void;
   onHideLobbyNamesChange: (checked: boolean) => void;
   onHideRemoteBallTexturesChange: (checked: boolean) => void;
@@ -135,11 +139,21 @@ export function bindLobbyEventHandlers(options: LobbyBindingsOptions) {
     }
     await options.onProfileBallHemi2TextureChange(file);
   });
+  options.profilePlayerBillboardTextureInput?.addEventListener('change', async () => {
+    const file = options.profilePlayerBillboardTextureInput?.files?.[0] ?? null;
+    if (options.profilePlayerBillboardTextureInput) {
+      options.profilePlayerBillboardTextureInput.value = '';
+    }
+    await options.onProfilePlayerBillboardTextureChange(file);
+  });
   options.profileBallHemi1TextureClearButton?.addEventListener('click', () => {
     options.onProfileBallHemi1TextureClear();
   });
   options.profileBallHemi2TextureClearButton?.addEventListener('click', () => {
     options.onProfileBallHemi2TextureClear();
+  });
+  options.profilePlayerBillboardTextureClearButton?.addEventListener('click', () => {
+    options.onProfilePlayerBillboardTextureClear();
   });
   options.hidePlayerNamesToggle?.addEventListener('change', () => {
     options.onHidePlayerNamesChange(!!options.hidePlayerNamesToggle?.checked);

--- a/src/app/netplay/message_flow.ts
+++ b/src/app/netplay/message_flow.ts
@@ -216,6 +216,7 @@ export class NetplayMessageFlowController {
     const baseProfile: PlayerProfile = {
       name: sanitized.name,
       ball: sanitized.ball,
+      playerBillboardTexture: sanitized.playerBillboardTexture,
     };
     this.deps.lobbyProfiles.set(playerId, baseProfile);
     if (broadcast) {
@@ -244,6 +245,7 @@ export class NetplayMessageFlowController {
         name: current?.name ?? sanitized.name,
         ball: current?.ball,
         avatarData,
+        playerBillboardTexture: current?.playerBillboardTexture ?? sanitized.playerBillboardTexture,
       };
       this.deps.lobbyProfiles.set(playerId, finalProfile);
       if (broadcast) {

--- a/src/app/netplay/profile_ui.ts
+++ b/src/app/netplay/profile_ui.ts
@@ -15,8 +15,11 @@ type ProfileUiDeps = {
   profileBallTextureError: HTMLElement | null;
   profileBallHemi1ColorInput: HTMLInputElement | null;
   profileBallHemi2ColorInput: HTMLInputElement | null;
+  profilePlayerBillboardTextureInput: HTMLInputElement | null;
   profileBallHemi1TextureClearButton: HTMLButtonElement | null;
   profileBallHemi2TextureClearButton: HTMLButtonElement | null;
+  profilePlayerBillboardTextureClearButton: HTMLButtonElement | null;
+  profilePlayerBillboardTextureError: HTMLElement | null;
   hidePlayerNamesToggle: HTMLInputElement | null;
   hideLobbyNamesToggle: HTMLInputElement | null;
   hideRemoteBallTexturesToggle: HTMLInputElement | null;
@@ -60,6 +63,22 @@ export class ProfileUiController {
     profileBallTextureError.textContent = '';
     profileBallTextureError.classList.add('hidden');
     profileBallTextureError.classList.remove('error');
+  }
+
+  setPlayerBillboardTextureError(message?: string) {
+    const { profilePlayerBillboardTextureError } = this.deps;
+    if (!profilePlayerBillboardTextureError) {
+      return;
+    }
+    if (message) {
+      profilePlayerBillboardTextureError.textContent = message;
+      profilePlayerBillboardTextureError.classList.remove('hidden');
+      profilePlayerBillboardTextureError.classList.add('error');
+      return;
+    }
+    profilePlayerBillboardTextureError.textContent = '';
+    profilePlayerBillboardTextureError.classList.add('hidden');
+    profilePlayerBillboardTextureError.classList.remove('error');
   }
 
   getAvatarValidationCached(dataUrl: string): Promise<boolean> {
@@ -116,6 +135,9 @@ export class ProfileUiController {
     }
     if (this.deps.profileBallHemi2TextureClearButton) {
       this.deps.profileBallHemi2TextureClearButton.disabled = !appearance.hemi2Texture;
+    }
+    if (this.deps.profilePlayerBillboardTextureClearButton) {
+      this.deps.profilePlayerBillboardTextureClearButton.disabled = !localProfile.playerBillboardTexture;
     }
   }
 }

--- a/src/app/netplay/profile_utils.ts
+++ b/src/app/netplay/profile_utils.ts
@@ -21,6 +21,11 @@ const PROFILE_BALL_TEXTURE_MAX_BYTES = 100 * 1024;
 const PROFILE_BALL_TEXTURE_MAX_DIM = 512;
 const PROFILE_BALL_TEXTURE_MAX_DATA_URL_CHARS = 160000;
 const PROFILE_BALL_TEXTURE_MIME = PROFILE_AVATAR_MIME;
+const PROFILE_BILLBOARD_TEXTURE_MAX_BYTES = 200 * 1024;
+const PROFILE_BILLBOARD_TEXTURE_MAX_WIDTH = 1024;
+const PROFILE_BILLBOARD_TEXTURE_MAX_HEIGHT = 768;
+const PROFILE_BILLBOARD_TEXTURE_MAX_DATA_URL_CHARS = 400000;
+const PROFILE_BILLBOARD_TEXTURE_MIME = PROFILE_AVATAR_MIME;
 const CHAT_MAX_CHARS = 200;
 
 export function sanitizeProfileName(value: string) {
@@ -82,6 +87,15 @@ export function sanitizeBallTextureDataUrl(value?: unknown): string | undefined 
     PROFILE_BALL_TEXTURE_MAX_DATA_URL_CHARS,
     PROFILE_BALL_TEXTURE_MAX_BYTES,
     PROFILE_BALL_TEXTURE_MIME,
+  );
+}
+
+export function sanitizePlayerBillboardTextureDataUrl(value?: unknown): string | undefined {
+  return sanitizeImageDataUrl(
+    value,
+    PROFILE_BILLBOARD_TEXTURE_MAX_DATA_URL_CHARS,
+    PROFILE_BILLBOARD_TEXTURE_MAX_BYTES,
+    PROFILE_BILLBOARD_TEXTURE_MIME,
   );
 }
 
@@ -148,6 +162,7 @@ export function sanitizeProfile(profile?: Partial<PlayerProfile>): PlayerProfile
     name: sanitizeProfileName(profile?.name ?? ''),
     avatarData: sanitizeAvatarDataUrl(profile?.avatarData),
     ball: sanitizeBallAppearanceProfile(profile?.ball),
+    playerBillboardTexture: sanitizePlayerBillboardTextureDataUrl(profile?.playerBillboardTexture),
   };
 }
 
@@ -212,6 +227,10 @@ function isAllowedAvatarFile(file: File) {
 
 function isAllowedBallTextureFile(file: File) {
   return isAllowedFileByMime(file, PROFILE_BALL_TEXTURE_MIME);
+}
+
+function isAllowedPlayerBillboardTextureFile(file: File) {
+  return isAllowedFileByMime(file, PROFILE_BILLBOARD_TEXTURE_MIME);
 }
 
 export async function validateAvatarFile(
@@ -283,6 +302,43 @@ export async function validateBallTextureFile(
   const sanitized = sanitizeBallTextureDataUrl(dataUrl);
   if (!sanitized) {
     setError('Ball texture could not be validated.');
+    return null;
+  }
+  return sanitized;
+}
+
+export async function validatePlayerBillboardTextureFile(
+  file: File,
+  setError: (message?: string) => void,
+): Promise<string | null> {
+  setError();
+  if (!isAllowedPlayerBillboardTextureFile(file)) {
+    setError('Player texture must be PNG, JPG, or WebP.');
+    return null;
+  }
+  if (file.size > PROFILE_BILLBOARD_TEXTURE_MAX_BYTES) {
+    setError('Player texture must be smaller than 200kb.');
+    return null;
+  }
+  const dimensions = await loadImageDimensionsFromFile(file);
+  if (!dimensions) {
+    setError('Failed to read player texture.');
+    return null;
+  }
+  if (dimensions.width > PROFILE_BILLBOARD_TEXTURE_MAX_WIDTH || dimensions.height > PROFILE_BILLBOARD_TEXTURE_MAX_HEIGHT) {
+    setError('Player texture must be a spritesheet and smaller than 1024x768.');
+    return null;
+  }
+  let dataUrl = '';
+  try {
+    dataUrl = await readFileAsDataUrl(file);
+  } catch {
+    setError('Failed to read player texture file.');
+    return null;
+  }
+  const sanitized = sanitizePlayerBillboardTextureDataUrl(dataUrl);
+  if (!sanitized) {
+    setError('Player texture could not be validated.');
     return null;
   }
   return sanitized;

--- a/src/app/netplay/profile_utils.ts
+++ b/src/app/netplay/profile_utils.ts
@@ -134,6 +134,7 @@ export function sanitizeBallAppearanceProfile(appearance?: Partial<BallAppearanc
   const hemi2Color = sanitizeBallColorHex(appearance.hemi2Color);
   const hemi1Texture = sanitizeBallTextureDataUrl(appearance.hemi1Texture);
   const hemi2Texture = sanitizeBallTextureDataUrl(appearance.hemi2Texture);
+  const billboardTexture = sanitizeBallTextureDataUrl(appearance.playerBillboardTexture);
   const compact: BallAppearanceProfile = {};
   if (hemi1Color && hemi1Color !== BALL_HEMI1_DEFAULT_COLOR) {
     compact.hemi1Color = hemi1Color;
@@ -146,6 +147,9 @@ export function sanitizeBallAppearanceProfile(appearance?: Partial<BallAppearanc
   }
   if (hemi2Texture) {
     compact.hemi2Texture = hemi2Texture;
+  }
+  if (billboardTexture) {
+    compact.playerBillboardTexture = billboardTexture;
   }
   return Object.keys(compact).length > 0 ? compact : undefined;
 }

--- a/src/app/render/frame_loop.ts
+++ b/src/app/render/frame_loop.ts
@@ -84,6 +84,9 @@ function applyBallAppearanceFromProfile(
   appearance.hemi2Texture = allowTextures && typeof profileBall?.hemi2Texture === 'string'
     ? profileBall.hemi2Texture
     : undefined;
+  appearance.playerBillboardTexture = allowTextures && typeof profile?.playerBillboardTexture === 'string'
+    ? profile.playerBillboardTexture
+    : undefined;
 }
 
 export function startRenderLoop(deps: FrameLoopDeps) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -392,7 +392,10 @@ export function runMainApp() {
   const ballPreview = new BallPreviewController({
     canvas: profileBallPreviewCanvas,
     loadPreviewStageData: (stageId) => stageLoader.loadSmb1(stageId),
-    getBallAppearance: () => localProfile.ball,
+    getBallAppearance: () => ({
+      ...localProfile.ball,
+      playerBillboardTexture: localProfile.playerBillboardTexture,
+    }),
   });
   
   let currentSmb2LikeMode: 'story' | 'challenge' | null = null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -88,6 +88,7 @@ import {
   savePrivacySettings,
   validateAvatarFile,
   validateBallTextureFile,
+  validatePlayerBillboardTextureFile,
 } from './app/netplay/profile_utils.js';
 import { PackLoader } from './app/packs/pack_loader.js';
 import { PackSelectionController } from './app/packs/pack_selection.js';
@@ -293,10 +294,13 @@ export function runMainApp() {
     profileBallHemi2ColorInput,
     profileBallHemi1TextureInput,
     profileBallHemi2TextureInput,
+    profilePlayerBillboardTextureInput,
     profileBallHemi1TextureClearButton,
     profileBallHemi2TextureClearButton,
+    profilePlayerBillboardTextureClearButton,
     profileBallPreviewCanvas,
     profileBallTextureError,
+    profilePlayerBillboardTextureError,
     hidePlayerNamesToggle,
     hideLobbyNamesToggle,
     hideRemoteBallTexturesToggle,
@@ -354,6 +358,9 @@ export function runMainApp() {
     profileBallHemi2ColorInput,
     profileBallHemi1TextureClearButton,
     profileBallHemi2TextureClearButton,
+    profilePlayerBillboardTextureInput,
+    profilePlayerBillboardTextureClearButton,
+    profilePlayerBillboardTextureError,
     hidePlayerNamesToggle,
     hideLobbyNamesToggle,
     hideRemoteBallTexturesToggle,
@@ -2071,8 +2078,10 @@ export function runMainApp() {
     profileBallHemi2ColorInput,
     profileBallHemi1TextureInput,
     profileBallHemi2TextureInput,
+    profilePlayerBillboardTextureInput,
     profileBallHemi1TextureClearButton,
     profileBallHemi2TextureClearButton,
+    profilePlayerBillboardTextureClearButton,
     hidePlayerNamesToggle,
     hideLobbyNamesToggle,
     hideRemoteBallTexturesToggle,
@@ -2194,6 +2203,32 @@ export function runMainApp() {
       }
       profileUi.setBallTextureError();
       applyLocalBallAppearancePatch({ hemi2Texture: undefined });
+    },
+    onProfilePlayerBillboardTextureChange: async (file) => {
+      if (!file) {
+        return;
+      }
+      const dataUrl = await validatePlayerBillboardTextureFile(file, (message) => {
+        profileUi.setPlayerBillboardTextureError(message);
+      });
+      if (!dataUrl) {
+        return;
+      }
+      profileUi.setPlayerBillboardTextureError();
+      localProfile = { ...localProfile, playerBillboardTexture: dataUrl };
+      saveLocalProfile(localProfile);
+      profileUi.updateProfileUi(localProfile);
+      lobbyState.scheduleProfileBroadcast();
+    },
+    onProfilePlayerBillboardTextureClear: () => {
+      if (!localProfile.playerBillboardTexture) {
+        return;
+      }
+      profileUi.setPlayerBillboardTextureError();
+      localProfile = { ...localProfile, playerBillboardTexture: undefined };
+      saveLocalProfile(localProfile);
+      profileUi.updateProfileUi(localProfile);
+      lobbyState.scheduleProfileBroadcast();
     },
     onHidePlayerNamesChange: (checked) => {
       privacySettings = { ...privacySettings, hidePlayerNames: checked };

--- a/src/netcode_protocol.ts
+++ b/src/netcode_protocol.ts
@@ -135,6 +135,7 @@ export type PlayerProfile = {
   name: string;
   avatarData?: string;
   ball?: BallAppearanceProfile;
+  playerBillboardTexture?: string;
 };
 
 export type PlayerProfileMessage = {

--- a/src/noclip/Render.ts
+++ b/src/noclip/Render.ts
@@ -87,6 +87,7 @@ export type BallRenderState = {
   visible: boolean;
   appearance?: BallAppearanceProfile;
   apeYaw: number;
+  speed: number;
 };
 
 export type BananaRenderState = {

--- a/src/noclip/Render.ts
+++ b/src/noclip/Render.ts
@@ -86,6 +86,7 @@ export type BallRenderState = {
   radius: number;
   visible: boolean;
   appearance?: BallAppearanceProfile;
+  apeYaw: number;
 };
 
 export type BananaRenderState = {

--- a/src/noclip/Render.ts
+++ b/src/noclip/Render.ts
@@ -88,6 +88,7 @@ export type BallRenderState = {
   appearance?: BallAppearanceProfile;
   apeYaw: number;
   speed: number;
+  goaled: boolean;
 };
 
 export type BananaRenderState = {

--- a/src/noclip/SuperMonkeyBall/World.ts
+++ b/src/noclip/SuperMonkeyBall/World.ts
@@ -120,6 +120,7 @@ export type BallRenderState = {
         hemi2Color?: string;
         hemi1Texture?: string;
         hemi2Texture?: string;
+        playerBillboardTexture?: string;
     };
     apeYaw: number;
     speed: number;
@@ -144,7 +145,7 @@ const SHADOW_FADE_SCALE = 0.2;
 const SHADOW_PARAMS_WORDS = 40;
 const SHADOW_UBO_INDEX = 1;
 const STREAK_VERTEX_SIZE = 24;
-const BALL_TEXTURE_MAX_DIM = 512;
+const BALL_TEXTURE_MAX_DIM = 1024;
 const BALL_HEMI_Y_ROT_180 = mat4.fromYRotation(mat4.create(), Math.PI);
 const BALL_COLOR_GAIN_EPSILON = 0.001;
 const BALL_COLOR_GAIN_MAX = 20.0;
@@ -873,7 +874,8 @@ class BallInst {
     private hemi2Color: [number, number, number] = [1, 1, 1];
     private hemi1Texture?: string;
     private hemi2Texture?: string;
-    private playerBillboardTexture: ModelInst | null = null;
+    private playerBillboardTexture?: string;
+    private playerBillboardModel: ModelInst;
     private spritesheetFrameCountX = 4;
     private spritesheetFrameCountY = 3;
     private lastApeYaw = 0;
@@ -918,7 +920,7 @@ class BallInst {
         }
         writeRgbFromHex(this.hemi1Color, this.hemi1ColorHex);
         writeRgbFromHex(this.hemi2Color, this.hemi2ColorHex);
-        this.playerBillboardTexture = modelCache.getModel(BALL_PLAYER_CHAR_BILLBOARD_MODEL, GmaSrc.Common);
+        this.playerBillboardModel = modelCache.getModel(BALL_PLAYER_CHAR_BILLBOARD_MODEL, GmaSrc.Common);
     }
 
     private computeSlotColorGains(model: ModelInst): [number, number, number] {
@@ -973,6 +975,7 @@ class BallInst {
         }
         this.hemi1Texture = typeof appearance?.hemi1Texture === "string" ? appearance.hemi1Texture : undefined;
         this.hemi2Texture = typeof appearance?.hemi2Texture === "string" ? appearance.hemi2Texture : undefined;
+        this.playerBillboardTexture = typeof appearance?.playerBillboardTexture === "string" ? appearance.playerBillboardTexture : undefined;
     }
 
     public setState(state: BallRenderState | null): void {
@@ -1057,8 +1060,8 @@ class BallInst {
             const scale = 0.333;
             mat4.scale(renderParams.viewFromModel, renderParams.viewFromModel, [scale, scale, -scale]);
             
-            // Apply hemi1 texture
-            const customTexture = this.resolveTextureMapping(this.hemi1Texture);
+            // Apply player billboard texture
+            const customTexture = this.resolveTextureMapping(this.playerBillboardTexture);
             if (customTexture && customTexture.gfxTexture && customTexture.gfxSampler) {
                 renderParams.textureOverride = customTexture;
                 renderParams.textureOverrideForceTex0 = true;
@@ -1141,7 +1144,7 @@ class BallInst {
             
             renderParams.disableSpecular = true;
             
-            this.playerBillboardTexture.prepareToRender(ctx, renderParams);
+            this.playerBillboardModel.prepareToRender(ctx, renderParams);
         }
     }
 }

--- a/src/noclip/SuperMonkeyBall/World.ts
+++ b/src/noclip/SuperMonkeyBall/World.ts
@@ -1075,7 +1075,8 @@ class BallInst {
 
                     const apeYawRad = this.lastApeYaw * S16_TO_RAD;
                     //console.log(`Ape yaw: ${apeYawRad*(180/Math.PI)}, camera angle: ${cameraRotY*(180/Math.PI)} speed: ${this.lastSpeed}`);
-                    const apeRelativeToCamRad = (apeYawRad - cameraRotY);
+                    let apeRelativeToCamRad = apeYawRad - cameraRotY;
+                    apeRelativeToCamRad = Math.atan2(Math.sin(apeRelativeToCamRad), Math.cos(apeRelativeToCamRad));
                     const apeRelativeToCamDeg = apeRelativeToCamRad * (180 / Math.PI);
                     //console.log(`Ape yaw: ${apeRelativeToCamDeg} deg`);
 
@@ -1083,7 +1084,7 @@ class BallInst {
                     const backThreshold = 50.0; // +- angle to determine whether or not we're going backward
 
                     const minimumSpeed = 0.02; // minimum speed ~2mph
-                    const maxSpeed = 0.4; // Full animation speed at 0.5m/frame - ~53mph
+                    const maxSpeed = 0.35; // Full animation speed at 0.5m/frame - ~53mph
 
                     // 4x3 grid has the following layout (I = idle, M = moving, B = backwards, F = forwards, R = right) (X = falling, G = goaled)
                     // IB, MB1, MB2, IF

--- a/src/noclip/SuperMonkeyBall/World.ts
+++ b/src/noclip/SuperMonkeyBall/World.ts
@@ -53,7 +53,7 @@ import type {
 } from "./Render.js";
 import * as SD from "./Stagedef.js";
 import { BgInfos, StageId, StageInfo } from "./StageInfo.js";
-import { MkbTime } from "./Utils.js";
+import {getMat4RotY, MkbTime} from "./Utils.js";
 import { AnimGroup } from "./AnimGroup.js";
 import { Lighting, LightingGroups } from "./Lighting.js";
 import { CommonModelID } from "./ModelInfo.js";
@@ -240,6 +240,7 @@ const scratchRevolutionAgFromWorld = mat4.create();
 const scratchRevolutionCameraWorld = vec3.create();
 const scratchRevolutionCameraLocal = vec3.create();
 const scratchRevolutionBallLocal = vec3.create();
+const BALL_PLAYER_CHAR_BILLBOARD_MODEL = "gb_grad"; // This model is offset by 0,1,1 in common.gma!
 
 function coligridLookupStagedef(animGroup: SD.AnimGroup, x: number, z: number): number[] | null {
     const stepX = animGroup.gridStepX;
@@ -870,6 +871,7 @@ class BallInst {
     private hemi2Color: [number, number, number] = [1, 1, 1];
     private hemi1Texture?: string;
     private hemi2Texture?: string;
+    private playerBillboardTexture: ModelInst | null = null;
 
     constructor(
         modelCache: ModelCache,
@@ -908,6 +910,7 @@ class BallInst {
         }
         writeRgbFromHex(this.hemi1Color, this.hemi1ColorHex);
         writeRgbFromHex(this.hemi2Color, this.hemi2ColorHex);
+        this.playerBillboardTexture = modelCache.getModel(BALL_PLAYER_CHAR_BILLBOARD_MODEL, GmaSrc.Common);
     }
 
     private computeSlotColorGains(model: ModelInst): [number, number, number] {
@@ -1019,6 +1022,41 @@ class BallInst {
             rp.textureOverride = textureOverride;
             rp.textureOverrideForceTex0 = textureOverride !== null;
             slot.model.prepareToRender(ctx, rp);
+        }
+
+        // Player texture billboard
+        if (this.playerBillboardTexture && this.visible) {
+            const renderParams = scratchRenderParams;
+            renderParams.reset();
+            renderParams.lighting = state.lighting;
+
+            const viewFromWorld = ctx.viewFromWorld ?? ctx.viewerInput.camera.viewMatrix;
+
+            mat4.copy(renderParams.viewFromModel, viewFromWorld);
+            mat4.translate(renderParams.viewFromModel, renderParams.viewFromModel, this.pos);
+
+            // Billboard
+            const cameraRotY = getMat4RotY(ctx.viewerInput.camera.worldMatrix);
+            mat4.rotateY(renderParams.viewFromModel, renderParams.viewFromModel, cameraRotY);
+
+            // Adjust since our model isn't centered in the ball.
+            // Y value may need to be tweaked depending on height
+            mat4.translate(renderParams.viewFromModel, renderParams.viewFromModel, vec3.fromValues(0, -0.25, 0.5));
+
+            // Scale may need to be tweaked depending on height
+            const scale = 0.333;
+            mat4.scale(renderParams.viewFromModel, renderParams.viewFromModel, [scale, scale, -scale]);
+            
+            // Apply hemi1 texture - placeholder
+            const customTexture = this.resolveTextureMapping(this.hemi1Texture);
+            if (customTexture && customTexture.gfxTexture && customTexture.gfxSampler) {
+                renderParams.textureOverride = customTexture;
+                renderParams.textureOverrideForceTex0 = true;
+            }
+            
+            renderParams.disableSpecular = true;
+            
+            this.playerBillboardTexture.prepareToRender(ctx, renderParams);
         }
     }
 }

--- a/src/noclip/SuperMonkeyBall/World.ts
+++ b/src/noclip/SuperMonkeyBall/World.ts
@@ -1135,7 +1135,7 @@ class BallInst {
                     let animFrameOffset = 0;
 
                     // Idle or goaled - ignore animation
-                    if (this.lastSpeed < minimumSpeed || this.hasGoaled || isFalling) {
+                    if (!isFalling && (this.lastSpeed < minimumSpeed || this.hasGoaled)) {
                         animFrameOffset = baseFrame;
                     }
                     // Falling animation doesn't have an idle frame

--- a/src/noclip/SuperMonkeyBall/World.ts
+++ b/src/noclip/SuperMonkeyBall/World.ts
@@ -57,7 +57,7 @@ import {getMat4RotY, MkbTime} from "./Utils.js";
 import { AnimGroup } from "./AnimGroup.js";
 import { Lighting, LightingGroups } from "./Lighting.js";
 import { CommonModelID } from "./ModelInfo.js";
-import { GAME_SOURCES } from "../../shared/constants/index.js";
+import {GAME_SOURCES, S16_TO_RAD} from "../../shared/constants/index.js";
 import {
     BALL_HEMI1_DEFAULT_COLOR,
     BALL_HEMI2_DEFAULT_COLOR,
@@ -121,6 +121,7 @@ export type BallRenderState = {
         hemi1Texture?: string;
         hemi2Texture?: string;
     };
+    apeYaw: number;
 };
 
 export type GoalTimerDigits = {
@@ -872,6 +873,9 @@ class BallInst {
     private hemi1Texture?: string;
     private hemi2Texture?: string;
     private playerBillboardTexture: ModelInst | null = null;
+    private spritesheetFrameCountX = 2;
+    private spritesheetFrameCountY = 2;
+    private lastApeYaw = 0;
 
     constructor(
         modelCache: ModelCache,
@@ -977,6 +981,7 @@ class BallInst {
         quat.set(this.rotation, state.orientation.x, state.orientation.y, state.orientation.z, state.orientation.w);
         const scale = state.radius / BALL_BASE_RADIUS;
         vec3.set(this.scale, scale, scale, scale);
+        this.lastApeYaw = state.apeYaw;
         this.updateAppearance(state);
     }
 
@@ -1047,11 +1052,55 @@ class BallInst {
             const scale = 0.333;
             mat4.scale(renderParams.viewFromModel, renderParams.viewFromModel, [scale, scale, -scale]);
             
-            // Apply hemi1 texture - placeholder
+            // Apply hemi1 texture
             const customTexture = this.resolveTextureMapping(this.hemi1Texture);
             if (customTexture && customTexture.gfxTexture && customTexture.gfxSampler) {
                 renderParams.textureOverride = customTexture;
                 renderParams.textureOverrideForceTex0 = true;
+                
+                if (customTexture.width > 0 && customTexture.height > 0 &&
+                    (this.spritesheetFrameCountX > 1 || this.spritesheetFrameCountY > 1)) {
+
+                    const apeYawRad = this.lastApeYaw * S16_TO_RAD;
+                    const apeRelativeToCamRad = apeYawRad - cameraRotY;
+                    const apeRelativeToCamDeg = apeRelativeToCamRad * (180 / Math.PI);
+                    //console.log(`Ape yaw: ${apeRelativeToCamDeg} deg`);
+
+                    let frameIndex: number;
+                    const forwardThreshold = 10.0;
+                    const backThreshold = 50.0;
+
+                    // Forward
+                    if (apeRelativeToCamDeg >= -forwardThreshold && apeRelativeToCamDeg <= forwardThreshold) {
+                        frameIndex = 0;
+                    }
+                    // Back
+                    else if (apeRelativeToCamDeg > backThreshold || apeRelativeToCamDeg < -backThreshold) {
+                        frameIndex = 1;
+                    }
+                    // Left
+                    else if (apeRelativeToCamDeg > forwardThreshold && apeRelativeToCamDeg <= backThreshold) {
+                        frameIndex = 2;
+                    }
+                    // Right
+                    else {
+                        frameIndex = 3;
+                    }
+
+                    const frameU = frameIndex % this.spritesheetFrameCountX;
+                    const frameV = Math.floor(frameIndex / this.spritesheetFrameCountX);
+                    
+                    const uOffset = frameU / this.spritesheetFrameCountX;
+                    const vOffset = frameV / this.spritesheetFrameCountY;
+                    const uSize = 1.0 / this.spritesheetFrameCountX;
+                    const vSize = 1.0 / this.spritesheetFrameCountY;
+                    
+                    mat4.translate(renderParams.texMtx2, renderParams.texMtx2, [uOffset, vOffset, 0.0]);
+                    mat4.scale(renderParams.texMtx2, renderParams.texMtx2, [uSize, vSize, 1.0]);
+                }
+                else {
+                    mat4.identity(renderParams.texMtx);
+                }
             }
             
             renderParams.disableSpecular = true;

--- a/src/noclip/SuperMonkeyBall/World.ts
+++ b/src/noclip/SuperMonkeyBall/World.ts
@@ -122,6 +122,7 @@ export type BallRenderState = {
         hemi2Texture?: string;
     };
     apeYaw: number;
+    speed: number;
 };
 
 export type GoalTimerDigits = {
@@ -873,9 +874,12 @@ class BallInst {
     private hemi1Texture?: string;
     private hemi2Texture?: string;
     private playerBillboardTexture: ModelInst | null = null;
-    private spritesheetFrameCountX = 2;
-    private spritesheetFrameCountY = 2;
+    private spritesheetFrameCountX = 4;
+    private spritesheetFrameCountY = 3;
     private lastApeYaw = 0;
+    private lastSpeed = 0;
+    private animTimer = 0;
+    private currentAnimFrame = 0;
 
     constructor(
         modelCache: ModelCache,
@@ -982,6 +986,7 @@ class BallInst {
         const scale = state.radius / BALL_BASE_RADIUS;
         vec3.set(this.scale, scale, scale, scale);
         this.lastApeYaw = state.apeYaw;
+        this.lastSpeed = state.speed;
         this.updateAppearance(state);
     }
 
@@ -1046,7 +1051,7 @@ class BallInst {
 
             // Adjust since our model isn't centered in the ball.
             // Y value may need to be tweaked depending on height
-            mat4.translate(renderParams.viewFromModel, renderParams.viewFromModel, vec3.fromValues(0, -0.25, 0.5));
+            mat4.translate(renderParams.viewFromModel, renderParams.viewFromModel, vec3.fromValues(0, -0.4, 0.33));
 
             // Scale may need to be tweaked depending on height
             const scale = 0.333;
@@ -1057,7 +1062,7 @@ class BallInst {
             if (customTexture && customTexture.gfxTexture && customTexture.gfxSampler) {
                 renderParams.textureOverride = customTexture;
                 renderParams.textureOverrideForceTex0 = true;
-                
+
                 if (customTexture.width > 0 && customTexture.height > 0 &&
                     (this.spritesheetFrameCountX > 1 || this.spritesheetFrameCountY > 1)) {
 
@@ -1066,35 +1071,66 @@ class BallInst {
                     const apeRelativeToCamDeg = apeRelativeToCamRad * (180 / Math.PI);
                     //console.log(`Ape yaw: ${apeRelativeToCamDeg} deg`);
 
-                    let frameIndex: number;
-                    const forwardThreshold = 10.0;
-                    const backThreshold = 50.0;
+                    const forwardThreshold = 8.0; // +- angle to determine whether or not we're going forward
+                    const backThreshold = 50.0; // +- angle to determine whether or not we're going backward
+
+                    const speedThreshold = 0.05;
+                    const maxSpeed = 0.5; // Full speed is considered to be 0.5
+
+                    // 4x3 grid has the following layout (I = idle, M = moving, B = backwards, F = forwards, R = right)
+                    // IB, MB1, MB2, IF
+                    // MF1, MF2, IR, MR1
+                    // MR2, -, -, -
+                    // this layout was taken from taronuke's mawaru gold marble rolling minigame because I don't know how to sprite sheet!
+
+                    let baseFrame: number;
+                    let isMirrored = false;
 
                     // Forward
                     if (apeRelativeToCamDeg >= -forwardThreshold && apeRelativeToCamDeg <= forwardThreshold) {
-                        frameIndex = 0;
+                        baseFrame = 3;
                     }
-                    // Back
+                    // Backwards
                     else if (apeRelativeToCamDeg > backThreshold || apeRelativeToCamDeg < -backThreshold) {
-                        frameIndex = 1;
+                        baseFrame = 0;
                     }
                     // Left
                     else if (apeRelativeToCamDeg > forwardThreshold && apeRelativeToCamDeg <= backThreshold) {
-                        frameIndex = 2;
+                        baseFrame = 6;
+                        isMirrored = true;
                     }
                     // Right
                     else {
-                        frameIndex = 3;
+                        baseFrame = 6;
                     }
 
-                    const frameU = frameIndex % this.spritesheetFrameCountX;
-                    const frameV = Math.floor(frameIndex / this.spritesheetFrameCountX);
-                    
-                    const uOffset = frameU / this.spritesheetFrameCountX;
-                    const vOffset = frameV / this.spritesheetFrameCountY;
-                    const uSize = 1.0 / this.spritesheetFrameCountX;
+                    const speedRatio = this.lastSpeed / maxSpeed;
+                    const framesPerSwitch = Math.max(15, Math.round(60.0 * (1.0 - speedRatio)));
+
+                    this.animTimer += 1;
+                    if (this.animTimer >= framesPerSwitch) {
+                        this.animTimer = 0;
+                        this.currentAnimFrame = this.currentAnimFrame === 0 ? 1 : 0;
+                    }
+
+                    const animFrameOffset = this.lastSpeed > speedThreshold ? 1 + this.currentAnimFrame : 0;
+                    const frameIndexWithAnim = baseFrame + animFrameOffset;
+                    //console.log(`I: ${frameIndexWithAnim} S: ${this.lastSpeed}, FPS: ${framesPerSwitch}, AF: ${this.currentAnimFrame}, AT: ${this.animTimer}`);
+
+                    const frameU = frameIndexWithAnim % this.spritesheetFrameCountX;
+                    const frameV = Math.floor(frameIndexWithAnim / this.spritesheetFrameCountX);
+
+                    let uOffset = frameU / this.spritesheetFrameCountX;
+                    let vOffset = frameV / this.spritesheetFrameCountY;
+                    let uSize = 1.0 / this.spritesheetFrameCountX;
                     const vSize = 1.0 / this.spritesheetFrameCountY;
-                    
+
+                    if (isMirrored) {
+                        uOffset = 1.0 - uOffset;
+                        vOffset = 1.0 - vOffset;
+                        uSize = -uSize;
+                    }
+
                     mat4.translate(renderParams.texMtx2, renderParams.texMtx2, [uOffset, vOffset, 0.0]);
                     mat4.scale(renderParams.texMtx2, renderParams.texMtx2, [uSize, vSize, 1.0]);
                 }

--- a/src/noclip/SuperMonkeyBall/World.ts
+++ b/src/noclip/SuperMonkeyBall/World.ts
@@ -57,7 +57,7 @@ import {getMat4RotY, MkbTime} from "./Utils.js";
 import { AnimGroup } from "./AnimGroup.js";
 import { Lighting, LightingGroups } from "./Lighting.js";
 import { CommonModelID } from "./ModelInfo.js";
-import {GAME_SOURCES, S16_TO_RAD} from "../../shared/constants/index.js";
+import {BALL_STATES, GAME_SOURCES, S16_TO_RAD} from "../../shared/constants/index.js";
 import {
     BALL_HEMI1_DEFAULT_COLOR,
     BALL_HEMI2_DEFAULT_COLOR,
@@ -68,6 +68,7 @@ import { S16_TO_RADIANS } from "./Utils.js";
 import { Vec3Zero, transformVec3Mat4w0, transformVec3Mat4w1 } from "../MathHelpers.js";
 import { TevLayerInst } from "./TevLayer.js";
 import { BONUS_WAVE_MODEL_NAME, BONUS_WAVE_VERTEX_GLOBAL, createBonusWaveMaterialHacks } from "./BonusWave.js";
+import {raycastStageDown} from "../../collision";
 
 // Immutable parsed stage definition
 export type StageData = {
@@ -124,6 +125,7 @@ export type BallRenderState = {
     };
     apeYaw: number;
     speed: number;
+    goaled: boolean;
 };
 
 export type GoalTimerDigits = {
@@ -880,6 +882,7 @@ class BallInst {
     private spritesheetFrameCountY = 3;
     private lastApeYaw = 0;
     private lastSpeed = 0;
+    private hasGoaled = false;
     private animTimer = 0;
     private currentAnimFrame = 0;
 
@@ -990,6 +993,7 @@ class BallInst {
         vec3.set(this.scale, scale, scale, scale);
         this.lastApeYaw = state.apeYaw;
         this.lastSpeed = state.speed;
+        this.hasGoaled = state.goaled;
         this.updateAppearance(state);
     }
 
@@ -1080,17 +1084,21 @@ class BallInst {
                     const speedThreshold = 0.05;
                     const maxSpeed = 0.5; // Full speed is considered to be 0.5
 
-                    // 4x3 grid has the following layout (I = idle, M = moving, B = backwards, F = forwards, R = right)
+                    // 4x3 grid has the following layout (I = idle, M = moving, B = backwards, F = forwards, R = right) (X = falling, G = goaled)
                     // IB, MB1, MB2, IF
                     // MF1, MF2, IR, MR1
-                    // MR2, -, -, -
+                    // MR2, X1, X2, G
                     // this layout was taken from taronuke's mawaru gold marble rolling minigame because I don't know how to sprite sheet!
 
                     let baseFrame: number;
                     let isMirrored = false;
 
+                    // Has goaled (OVERRIDES EVERYTHING ELSE - INCLUDING ANIMATION
+                    if (this.hasGoaled) {
+                        baseFrame = 11;
+                    }
                     // Forward
-                    if (apeRelativeToCamDeg >= -forwardThreshold && apeRelativeToCamDeg <= forwardThreshold) {
+                    else if (apeRelativeToCamDeg >= -forwardThreshold && apeRelativeToCamDeg <= forwardThreshold) {
                         baseFrame = 3;
                     }
                     // Backwards
@@ -1117,8 +1125,13 @@ class BallInst {
                     }
 
                     const animFrameOffset = this.lastSpeed > speedThreshold ? 1 + this.currentAnimFrame : 0;
-                    const frameIndexWithAnim = baseFrame + animFrameOffset;
+                    let frameIndexWithAnim = baseFrame + animFrameOffset;
                     //console.log(`I: ${frameIndexWithAnim} S: ${this.lastSpeed}, FPS: ${framesPerSwitch}, AF: ${this.currentAnimFrame}, AT: ${this.animTimer}`);
+
+                    // Goaled state ignores animation
+                    if (this.hasGoaled) {
+                        frameIndexWithAnim = baseFrame;
+                    }
 
                     const frameU = frameIndexWithAnim % this.spritesheetFrameCountX;
                     const frameV = Math.floor(frameIndexWithAnim / this.spritesheetFrameCountX);

--- a/src/noclip/SuperMonkeyBall/World.ts
+++ b/src/noclip/SuperMonkeyBall/World.ts
@@ -991,8 +991,8 @@ class BallInst {
         quat.set(this.rotation, state.orientation.x, state.orientation.y, state.orientation.z, state.orientation.w);
         const scale = state.radius / BALL_BASE_RADIUS;
         vec3.set(this.scale, scale, scale, scale);
-        this.lastApeYaw = state.apeYaw;
         this.lastSpeed = state.speed;
+        this.lastApeYaw = state.apeYaw;
         this.hasGoaled = state.goaled;
         this.updateAppearance(state);
     }
@@ -1074,15 +1074,16 @@ class BallInst {
                     (this.spritesheetFrameCountX > 1 || this.spritesheetFrameCountY > 1)) {
 
                     const apeYawRad = this.lastApeYaw * S16_TO_RAD;
-                    const apeRelativeToCamRad = apeYawRad - cameraRotY;
+                    //console.log(`Ape yaw: ${apeYawRad*(180/Math.PI)}, camera angle: ${cameraRotY*(180/Math.PI)} speed: ${this.lastSpeed}`);
+                    const apeRelativeToCamRad = (apeYawRad - cameraRotY);
                     const apeRelativeToCamDeg = apeRelativeToCamRad * (180 / Math.PI);
                     //console.log(`Ape yaw: ${apeRelativeToCamDeg} deg`);
 
-                    const forwardThreshold = 8.0; // +- angle to determine whether or not we're going forward
+                    const forwardThreshold = 7.5; // +- angle to determine whether or not we're going forward
                     const backThreshold = 50.0; // +- angle to determine whether or not we're going backward
 
-                    const speedThreshold = 0.05;
-                    const maxSpeed = 0.5; // Full speed is considered to be 0.5
+                    const minimumSpeed = 0.02; // minimum speed ~2mph
+                    const maxSpeed = 0.4; // Full animation speed at 0.5m/frame - ~53mph
 
                     // 4x3 grid has the following layout (I = idle, M = moving, B = backwards, F = forwards, R = right) (X = falling, G = goaled)
                     // IB, MB1, MB2, IF
@@ -1092,13 +1093,20 @@ class BallInst {
 
                     let baseFrame: number;
                     let isMirrored = false;
+                    let isFalling = false;
 
                     // Has goaled (OVERRIDES EVERYTHING ELSE - INCLUDING ANIMATION
                     if (this.hasGoaled) {
                         baseFrame = 11;
                     }
-                    // Forward
-                    else if (apeRelativeToCamDeg >= -forwardThreshold && apeRelativeToCamDeg <= forwardThreshold) {
+                    // Are we falling, or going way too fast (>200mph)?
+                    else if (this.lastSpeed > 1.5 || !state.raycastStageDown(this.pos)) {
+                        baseFrame = 9;
+                        isFalling = true;
+                    }
+                    // Forward - also if we're going too fast, just assume that we're going forwards
+                    // This is because apeyaw is unreliable above the max speed. TODO: a better way?
+                    else if ( (apeRelativeToCamDeg >= -forwardThreshold && apeRelativeToCamDeg <= forwardThreshold) || this.lastSpeed >= maxSpeed) {
                         baseFrame = 3;
                     }
                     // Backwards
@@ -1115,7 +1123,7 @@ class BallInst {
                         baseFrame = 6;
                     }
 
-                    const speedRatio = this.lastSpeed / maxSpeed;
+                    const speedRatio = Math.min(this.lastSpeed, maxSpeed) / maxSpeed;
                     const framesPerSwitch = Math.max(15, Math.round(60.0 * (1.0 - speedRatio)));
 
                     this.animTimer += 1;
@@ -1124,27 +1132,44 @@ class BallInst {
                         this.currentAnimFrame = this.currentAnimFrame === 0 ? 1 : 0;
                     }
 
-                    const animFrameOffset = this.lastSpeed > speedThreshold ? 1 + this.currentAnimFrame : 0;
-                    let frameIndexWithAnim = baseFrame + animFrameOffset;
-                    //console.log(`I: ${frameIndexWithAnim} S: ${this.lastSpeed}, FPS: ${framesPerSwitch}, AF: ${this.currentAnimFrame}, AT: ${this.animTimer}`);
+                    let animFrameOffset = 0;
 
-                    // Goaled state ignores animation
-                    if (this.hasGoaled) {
-                        frameIndexWithAnim = baseFrame;
+                    // Idle or goaled - ignore animation
+                    if (this.lastSpeed < minimumSpeed || this.hasGoaled || isFalling) {
+                        animFrameOffset = baseFrame;
+                    }
+                    // Falling animation doesn't have an idle frame
+                    else if (isFalling) {
+                        animFrameOffset = baseFrame + this.currentAnimFrame;
+                    }
+                    else {
+                        animFrameOffset = baseFrame + this.currentAnimFrame+1;
                     }
 
-                    const frameU = frameIndexWithAnim % this.spritesheetFrameCountX;
-                    const frameV = Math.floor(frameIndexWithAnim / this.spritesheetFrameCountX);
+                    //console.log(`I: ${frameIndexWithAnim} S: ${this.lastSpeed}, FPS: ${framesPerSwitch}, AF: ${this.currentAnimFrame}, AT: ${this.animTimer}`);
 
-                    let uOffset = frameU / this.spritesheetFrameCountX;
-                    let vOffset = frameV / this.spritesheetFrameCountY;
-                    let uSize = 1.0 / this.spritesheetFrameCountX;
-                    const vSize = 1.0 / this.spritesheetFrameCountY;
+                    let frameU: number;
+                    let frameV: number;
+                    let uOffset: number;
+                    let vOffset: number;
+                    let uSize: number;
+                    let vSize: number;
 
                     if (isMirrored) {
-                        uOffset = 1.0 - uOffset;
-                        vOffset = 1.0 - vOffset;
-                        uSize = -uSize;
+                        frameU = animFrameOffset % this.spritesheetFrameCountX;
+                        frameV = Math.floor(animFrameOffset / this.spritesheetFrameCountX);
+                        uOffset = (frameU + 1) / this.spritesheetFrameCountX;
+                        vOffset = (frameV) / this.spritesheetFrameCountY;
+                        uSize = -1.0 / this.spritesheetFrameCountX;
+                        vSize = 1.0 / this.spritesheetFrameCountY;
+                    }
+                    else {
+                        frameU = animFrameOffset % this.spritesheetFrameCountX;
+                        frameV = Math.floor(animFrameOffset / this.spritesheetFrameCountX);
+                        uOffset = frameU / this.spritesheetFrameCountX;
+                        vOffset = frameV / this.spritesheetFrameCountY;
+                        uSize = 1.0 / this.spritesheetFrameCountX;
+                        vSize = 1.0 / this.spritesheetFrameCountY;
                     }
 
                     mat4.translate(renderParams.texMtx2, renderParams.texMtx2, [uOffset, vOffset, 0.0]);

--- a/src/shared/ball_appearance.ts
+++ b/src/shared/ball_appearance.ts
@@ -37,6 +37,7 @@ export function resolveBallAppearance(appearance?: BallAppearanceProfile | null)
     hemi2Color: normalizeBallColorHex(appearance?.hemi2Color, BALL_HEMI2_DEFAULT_COLOR),
     hemi1Texture: typeof appearance?.hemi1Texture === 'string' ? appearance.hemi1Texture : undefined,
     hemi2Texture: typeof appearance?.hemi2Texture === 'string' ? appearance.hemi2Texture : undefined,
+    playerBillboardTexture: typeof appearance?.playerBillboardTexture === 'string' ? appearance.playerBillboardTexture : undefined,
   };
 }
 

--- a/src/shared/ball_appearance.ts
+++ b/src/shared/ball_appearance.ts
@@ -3,6 +3,7 @@ export type BallAppearanceProfile = {
   hemi2Color?: string;
   hemi1Texture?: string;
   hemi2Texture?: string;
+  playerBillboardTexture?: string;
 };
 
 export type BallAppearanceResolved = {
@@ -10,6 +11,7 @@ export type BallAppearanceResolved = {
   hemi2Color: string;
   hemi1Texture?: string;
   hemi2Texture?: string;
+  playerBillboardTexture?: string;
 };
 
 const BALL_COLOR_HEX_RE = /^#[0-9a-f]{6}$/i;
@@ -45,7 +47,8 @@ export function ballAppearanceProfilesEqual(
   return (a?.hemi1Color ?? '') === (b?.hemi1Color ?? '')
     && (a?.hemi2Color ?? '') === (b?.hemi2Color ?? '')
     && (a?.hemi1Texture ?? '') === (b?.hemi1Texture ?? '')
-    && (a?.hemi2Texture ?? '') === (b?.hemi2Texture ?? '');
+    && (a?.hemi2Texture ?? '') === (b?.hemi2Texture ?? '')
+    && (a?.playerBillboardTexture ?? '') === (b?.playerBillboardTexture ?? '');
 }
 
 export function writeRgbFromHex(out: [number, number, number], hex: string): void {

--- a/src/sim/game_core.ts
+++ b/src/sim/game_core.ts
@@ -2528,6 +2528,7 @@ export class GameCore {
         visible: (this.ball.flags & BALL_FLAGS.INVISIBLE) === 0,
         apeYaw: 0,
         speed: 0,
+        goaled: false,
       };
     }
     const renderState = this.renderBallState;
@@ -2550,6 +2551,7 @@ export class GameCore {
     renderState.visible = (this.ball.flags & BALL_FLAGS.INVISIBLE) === 0;
     renderState.apeYaw = this.ball.apeYaw;
     renderState.speed = this.ball.speed;
+    renderState.goaled = (this.ball.flags & BALL_FLAGS.GOAL) === BALL_FLAGS.GOAL;
 
     return this.renderBallState;
   }
@@ -2577,6 +2579,7 @@ export class GameCore {
           visible: (ball.flags & BALL_FLAGS.INVISIBLE) === 0,
           apeYaw: 0,
           speed: 0,
+          goaled: false,
         };
       }
     }
@@ -2605,6 +2608,7 @@ export class GameCore {
         && (ball.flags & BALL_FLAGS.INVISIBLE) === 0;
       renderState.apeYaw = ball.apeYaw;
       renderState.speed = ball.speed;
+      renderState.goaled = (ball.flags & BALL_FLAGS.GOAL) === BALL_FLAGS.GOAL;
     }
     return this.renderBallStates;
   }

--- a/src/sim/game_core.ts
+++ b/src/sim/game_core.ts
@@ -2526,6 +2526,7 @@ export class GameCore {
         },
         radius: this.ball.currRadius,
         visible: (this.ball.flags & BALL_FLAGS.INVISIBLE) === 0,
+        apeYaw: 0,
       };
     }
     const renderState = this.renderBallState;
@@ -2546,6 +2547,8 @@ export class GameCore {
     }
     renderState.radius = this.ball.currRadius;
     renderState.visible = (this.ball.flags & BALL_FLAGS.INVISIBLE) === 0;
+    renderState.apeYaw = this.ball.apeYaw;
+
     return this.renderBallState;
   }
 
@@ -2570,6 +2573,7 @@ export class GameCore {
           },
           radius: ball.currRadius,
           visible: (ball.flags & BALL_FLAGS.INVISIBLE) === 0,
+          apeYaw: 0,
         };
       }
     }
@@ -2596,6 +2600,7 @@ export class GameCore {
       renderState.visible = !player.isSpectator
         && !player.pendingSpawn
         && (ball.flags & BALL_FLAGS.INVISIBLE) === 0;
+      renderState.apeYaw = this.ball.apeYaw;
     }
     return this.renderBallStates;
   }

--- a/src/sim/game_core.ts
+++ b/src/sim/game_core.ts
@@ -2527,6 +2527,7 @@ export class GameCore {
         radius: this.ball.currRadius,
         visible: (this.ball.flags & BALL_FLAGS.INVISIBLE) === 0,
         apeYaw: 0,
+        speed: 0,
       };
     }
     const renderState = this.renderBallState;
@@ -2548,6 +2549,7 @@ export class GameCore {
     renderState.radius = this.ball.currRadius;
     renderState.visible = (this.ball.flags & BALL_FLAGS.INVISIBLE) === 0;
     renderState.apeYaw = this.ball.apeYaw;
+    renderState.speed = this.ball.speed;
 
     return this.renderBallState;
   }
@@ -2574,6 +2576,7 @@ export class GameCore {
           radius: ball.currRadius,
           visible: (ball.flags & BALL_FLAGS.INVISIBLE) === 0,
           apeYaw: 0,
+          speed: 0,
         };
       }
     }
@@ -2600,7 +2603,8 @@ export class GameCore {
       renderState.visible = !player.isSpectator
         && !player.pendingSpawn
         && (ball.flags & BALL_FLAGS.INVISIBLE) === 0;
-      renderState.apeYaw = this.ball.apeYaw;
+      renderState.apeYaw = ball.apeYaw;
+      renderState.speed = ball.speed;
     }
     return this.renderBallStates;
   }

--- a/src/sim/state.ts
+++ b/src/sim/state.ts
@@ -66,6 +66,7 @@ export type BallRenderState = {
   visible: boolean;
   appearance?: BallAppearanceProfile;
   apeYaw: number;
+  speed: number;
 };
 
 export type CameraPose = { eye: Vec3; lookAt: Vec3; rotX: number; rotY: number; rotZ: number };

--- a/src/sim/state.ts
+++ b/src/sim/state.ts
@@ -67,6 +67,7 @@ export type BallRenderState = {
   appearance?: BallAppearanceProfile;
   apeYaw: number;
   speed: number;
+  goaled: boolean;
 };
 
 export type CameraPose = { eye: Vec3; lookAt: Vec3; rotX: number; rotY: number; rotZ: number };

--- a/src/sim/state.ts
+++ b/src/sim/state.ts
@@ -65,6 +65,7 @@ export type BallRenderState = {
   radius: number;
   visible: boolean;
   appearance?: BallAppearanceProfile;
+  apeYaw: number;
 };
 
 export type CameraPose = { eye: Vec3; lookAt: Vec3; rotX: number; rotY: number; rotZ: number };


### PR DESCRIPTION
This feature adds player billboard sprites to the game!

A bullet-pointed summary of everything to note:
- Player sprites are implemented as a 4x3 spritesheet, maximum resolution 1024x768, and maximum size 200KB.
- Other players are able to see player sprites - disabling seeing remote customization should also disable player sprites.
- Player sprites are animated depending on the direction the player is facing. The faster the player is travelling, the faster the animation plays. 
    - As a side note... `apeYaw` breaks down at high speeds, possibly due to the character rolling around in the ball in the base game? I haven't fixed this yet and just assume forward direction.
    - You can tweak angle and speed settings in `World.ts` to your liking. See the constants around line 1082.
- When the player is falling (raycast below player fails), the falling animation plays. The falling animation also plays when the player is travelling faster than 200mph. I thought this was funny.
- When the player goals, the goal frame is always displayed.
- The player sprite is billboarded to the camera's Y axis.

Here is the template for sprite sheets - just remove the pink bits after filling stuff in.
<img width="1024" height="768" alt="spritesheet-template" src="https://github.com/user-attachments/assets/35d385e2-2d98-4ea5-814d-a54003919a27" />

Let me know if you have any questions!